### PR TITLE
Blocking bootstrapping with split

### DIFF
--- a/src/app/features/features.component.ts
+++ b/src/app/features/features.component.ts
@@ -13,6 +13,6 @@ export class FeaturesComponent implements OnInit {
   constructor(public splitioService: SplitioService) { }
 
   ngOnInit() {
-    this.splitioService.initSdk();
+    this.splitioService.getTreatments();
   }
 }

--- a/src/app/splitio.service.ts
+++ b/src/app/splitio.service.ts
@@ -1,58 +1,14 @@
 import { Injectable } from '@angular/core';
-import { SplitFactory } from '@splitsoftware/splitio';
-import { fromEvent } from 'rxjs/observable/fromEvent';
+import { client as splitClient } from '../splitio';
 
 @Injectable()
 export class SplitioService {
 
-  splitio: SplitIO.ISDK;
-  splitClient: SplitIO.IClient;
-  isReady: boolean = false;
+  splitClient: SplitIO.IClient = splitClient;
   treatments: SplitIO.Treatments
   features: string[] = [
-    'feature_1',
-    'feature_2',
-    'feature_3'
+    'editor_no_modal'
   ];
-
-  constructor() { }
-
-  initSdk(): void {
-    // Running the SDK in 'off-the-grid' Mode since authorizationKey : 'localhost'
-    // To bind a non 'off-the-grid' client, inject the real API Key
-    this.splitio = SplitFactory({
-      core: {
-        authorizationKey: 'localhost',
-        key: 'customer-key'
-      },
-      // In non-localhost mode, this map is ignored.
-      features: {
-        feature_1: 'off',
-        feature_2: 'on',
-        feature_3: 'v2'
-      }
-    });
-
-    this.splitClient = this.splitio.client();
-
-    // verify if sdk is initialized
-    this.verifyReady();
-  }
-
-  private verifyReady(): void {
-    const isReadyEvent = fromEvent(this.splitClient, this.splitClient.Event.SDK_READY);
-
-    const subscription = isReadyEvent.subscribe({
-      next() { 
-        this.isReady = true;
-        console.log('Sdk ready: ', this.isReady);         
-      },
-      error(err) { 
-        console.log('Sdk error: ', err); 
-        this.isReady = false;
-      }
-    });
-  }
 
   getTreatments(): void {
     this.treatments = this.splitClient.getTreatments(this.features);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,15 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
+import { isSdkReady } from './splitio';
+
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+isSdkReady.subscribe(() => {
+  if (environment.production) {
+    enableProdMode();
+  }
 
-if (environment.production) {
-  enableProdMode();
-}
+  platformBrowserDynamic().bootstrapModule(AppModule);
+});
 
-platformBrowserDynamic().bootstrapModule(AppModule);

--- a/src/splitio.ts
+++ b/src/splitio.ts
@@ -1,0 +1,20 @@
+import { SplitFactory } from '@splitsoftware/splitio';
+import { fromEvent } from 'rxjs/observable/fromEvent';
+
+const client = SplitFactory({
+  core: {
+    authorizationKey: 'your-api-key',
+    key: 'customer-key'
+  },
+  startup: {
+    readyTimeout: 20,
+    requestTimeoutBeforeReady: 20
+  }
+}).client();
+
+const isSdkReady = fromEvent(client, client.Event.SDK_READY);
+
+export {
+  client,
+  isSdkReady
+};


### PR DESCRIPTION
One option would be to just tackle that from TypeScript, prior to Angular bootstrapping. 

You can download this branch and check this example. I'm using an observable created with rxjs `fromEvent` method, which would be one way to get notified when the SDK is ready.

This would block all angular app code until SDK is ready.