### PR TITLE
Example resolver for render blocking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,13 +253,14 @@
       }
     },
     "@splitsoftware/splitio": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.2.0.tgz",
-      "integrity": "sha512-bmUCKYT0YfncCrSee/OrvoGK3lV7XwisIZXwCKAIFpwSeH2K/OZThX0aYBj77TyTJd2Rbsk7WN3L4vYlD6E0Rg==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio/-/splitio-10.3.2.tgz",
+      "integrity": "sha512-t/eQ0QXeaK1eypVWG6t1lJ7HghksG1QUXZ1Y8/FbG9LtU6iuqu4Kr/Kxe3iVnVOUACAhWhT22Did/u+mN8tX/w==",
       "requires": {
         "@types/node": "9.4.7",
         "axios": "0.18.0",
         "babel-runtime": "6.26.0",
+        "events": "3.0.0",
         "ioredis": "3.2.2",
         "ip": "1.1.5",
         "lodash": "4.17.5",
@@ -271,6 +272,14 @@
           "version": "9.4.7",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
           "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw=="
+        },
+        "events": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+          "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+        },
+        "logplease": {
+          "version": "github:NicoZelaya/logplease#b4ca204f892080a2011fe3b3f3b2b1c8c72bb29c"
         }
       }
     },
@@ -6241,9 +6250,6 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
       "dev": true
-    },
-    "logplease": {
-      "version": "github:NicoZelaya/logplease#b4ca204f892080a2011fe3b3f3b2b1c8c72bb29c"
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-server": "~5.0.0",
     "@angular/router": "~5.0.0",
     "@angular/upgrade": "~5.0.0",
-    "@splitsoftware/splitio": "^10.2.0",
+    "@splitsoftware/splitio": "^10.3.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.5.0",
     "zone.js": "^0.8.4"

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule }             from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { FeaturesComponent }   from './features/features.component';
+
+// We'll only resolve Split here but we could potentially
+// use it for other prerrequisite data.
+import { AppResolver } from './app.resolver';
+
+const routes: Routes = [
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: 'home', component: FeaturesComponent, resolve: {
+    prerrequisitesReady: AppResolver
+  }}
+];
+
+@NgModule({
+  imports: [ RouterModule.forRoot(routes) ],
+  exports: [ RouterModule ]
+})
+export class AppRoutingModule {}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
 <h1>{{title}}</h1>
-<app-features></app-features>
+<!-- Here's where our actual page will be -->
+<router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,5 +6,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  title = 'Example App Angular';
+  title = 'App component is kind of dumb, used for root <router-outlet>';
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,20 +4,26 @@ import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
 
+import { AppRoutingModule } from './app-routing.module';
+
 // splitio sdk
 import { SplitioService } from './splitio.service';
+import { AppResolver } from './app.resolver';
 import { FeaturesComponent } from './features/features.component';
 
 @NgModule({
   imports: [
     BrowserModule,
-    FormsModule
+    FormsModule,
+    AppRoutingModule
   ],
   declarations: [
     AppComponent,
     FeaturesComponent
   ],
-  providers: [ 
+  providers: [
+    // Import the resolver
+    AppResolver,
     SplitioService
   ],
   bootstrap: [ AppComponent ]

--- a/src/app/app.resolver.ts
+++ b/src/app/app.resolver.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+import { SplitioService } from './splitio.service';
+
+@Injectable()
+export class AppResolver implements Resolve<any> {
+  // Inject the service on the resolver.
+  constructor(private splitService: SplitioService) {}
+
+  resolve() {
+    // Use it on the resolve function and return a promise
+    // for the ready.
+    return this.splitService.getReadyPromise();
+  }
+}

--- a/src/app/features/features.component.ts
+++ b/src/app/features/features.component.ts
@@ -13,6 +13,6 @@ export class FeaturesComponent implements OnInit {
   constructor(public splitioService: SplitioService) { }
 
   ngOnInit() {
-    this.splitioService.initSdk();
+    this.splitioService.getTreatments();
   }
 }

--- a/src/app/splitio.service.ts
+++ b/src/app/splitio.service.ts
@@ -10,26 +10,18 @@ export class SplitioService {
   isReady: boolean = false;
   treatments: SplitIO.Treatments
   features: string[] = [
-    'feature_1',
-    'feature_2',
-    'feature_3'
+    'feature_1', 'feature_2'
   ];
 
-  constructor() { }
+  constructor() {
+    this.initSdk();
+  }
 
   initSdk(): void {
-    // Running the SDK in 'off-the-grid' Mode since authorizationKey : 'localhost'
-    // To bind a non 'off-the-grid' client, inject the real API Key
     this.splitio = SplitFactory({
       core: {
-        authorizationKey: 'localhost',
+        authorizationKey: 'your-api-key',
         key: 'customer-key'
-      },
-      // In non-localhost mode, this map is ignored.
-      features: {
-        feature_1: 'off',
-        feature_2: 'on',
-        feature_3: 'v2'
       }
     });
 
@@ -39,16 +31,20 @@ export class SplitioService {
     this.verifyReady();
   }
 
+  getReadyPromise(): Promise<boolean> {
+    return this.splitClient.ready().then(()=> true).catch(() => false);
+  }
+
   private verifyReady(): void {
     const isReadyEvent = fromEvent(this.splitClient, this.splitClient.Event.SDK_READY);
 
     const subscription = isReadyEvent.subscribe({
-      next() { 
+      next() {
         this.isReady = true;
-        console.log('Sdk ready: ', this.isReady);         
+        console.log('Sdk ready: ', this.isReady);
       },
-      error(err) { 
-        console.log('Sdk error: ', err); 
+      error(err) {
+        console.log('Sdk error: ', err);
         this.isReady = false;
       }
     });


### PR DESCRIPTION
Another option would be to use a [resolver](https://angular.io/api/router/Resolve) to block the routing on the main route. 

I'm using here the `client.ready()` method which returns a promise as an example of another way, but I would recommend the `fromEvent` from rxjs that's used on the other example.

With this, the Angular app will load, but you can prevent rendering.